### PR TITLE
be more resilient to ElastiCache failures

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+elixir 1.4.2
+erlang 19.0

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,8 @@
 use Mix.Config
 
 config :memcachir,
-  hosts: "localhost",
-  pool: [
-    size: 1]
+  pool: [size: 2],
+  health_check: 100
+
+config :elasticachex,
+  socket_module: MockSocketModule

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  memcached:
+    image: memcached
+    ports:
+      - '11211:11211'

--- a/lib/memcachir/cluster.ex
+++ b/lib/memcachir/cluster.ex
@@ -1,0 +1,39 @@
+defmodule Memcachir.Cluster do
+  use GenServer
+  require Logger
+
+  alias Memcachir.Util
+
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options, name: __MODULE__)
+  end
+
+  def init(options) do
+    servers = Util.get_servers(options)
+    Logger.info("starting cluster with servers: #{inspect servers}")
+
+    ring =
+      servers
+      |> Enum.reduce(HashRing.new(), fn({host, port}, ring) ->
+        HashRing.add_node(ring, {host, port})
+      end)
+
+    {:ok, ring}
+  end
+
+  def servers() do
+    GenServer.call(__MODULE__, :servers)
+  end
+
+  def key_to_node(key) do
+    GenServer.call(__MODULE__, {:node, key})
+  end
+
+  def handle_call(:servers, _from, ring) do
+    {:reply, HashRing.nodes(ring), ring}
+  end
+
+  def handle_call({:node, key}, _from, ring) do
+    {:reply, HashRing.key_to_node(ring, key), ring}
+  end
+end

--- a/lib/memcachir/health.ex
+++ b/lib/memcachir/health.ex
@@ -1,0 +1,37 @@
+defmodule Memcachir.HealthCheck do
+  use GenServer
+
+  alias Memcachir.{Cluster, Util}
+
+  @default_delay 60_000
+
+  def start_link(options) do
+    GenServer.start_link(__MODULE__, options, name: __MODULE__)
+  end
+
+  def init(options) do
+    # only need to poll if using ElastiCache
+    if Keyword.has_key?(options, :elasticache) do
+      schedule_health_check(options)
+    end
+
+    {:ok, options}
+  end
+
+  def handle_info(:check, options) do
+    known_servers = Cluster.servers() |> Enum.into(MapSet.new)
+    actual_servers = Util.get_servers(options) |> Enum.into(MapSet.new)
+
+    if MapSet.equal?(known_servers, actual_servers) do
+      schedule_health_check(options)
+      {:noreply, options}
+    else
+      {:stop, "ElastiCache servers changed from #{inspect known_servers} to #{inspect actual_servers}", options}
+    end
+  end
+
+  defp schedule_health_check(options) do
+    delay = Keyword.get(options, :health_check) || @default_delay
+    Process.send_after(self(), :check, delay)
+  end
+end

--- a/lib/memcachir/supervisor.ex
+++ b/lib/memcachir/supervisor.ex
@@ -1,28 +1,21 @@
 defmodule Memcachir.Supervisor do
   use Supervisor
+  require Logger
 
-  alias Memcachir.Util
+  alias Memcachir.{Cluster, HealthCheck, Pool}
 
-  def start_link(options, pool_options) do
-    Supervisor.start_link(__MODULE__, [options, pool_options])
+  def start_link(options) do
+    Supervisor.start_link(__MODULE__, options, name: __MODULE__)
   end
 
-  def init([options, pool_options]) do
-    # set a worker for every host in servers
-    children = Enum.map(options[:servers], fn({host, port}) ->
-      name = Util.host_to_atom(host, port)
-      options =
-        options
-        |> Keyword.put(:hostname, host)
-        |> Keyword.put(:port, port)
-      pool_options =
-        pool_options
-        |> Keyword.put(:name, {:local, name})
-      worker(Memcachir.Pool, [options, pool_options], id: name)
-    end)
+  def init(options) do
+    children = [
+      worker(Cluster, [options]), # needs to be started FIRST
+      worker(HealthCheck, [options]),
+      supervisor(Pool, [options]),
+    ]
 
-    opts = [strategy: :one_for_one]
-
-    supervise(children, opts)
+    # if the health check dies (e.g. because a node was added/removed), restart everything
+    supervise(children, strategy: :one_for_all)
   end
 end

--- a/lib/memcachir/worker.ex
+++ b/lib/memcachir/worker.ex
@@ -1,6 +1,0 @@
-defmodule Memcachir.Worker do
-
-  def start_link(options) do
-    Memcache.start_link(options)
-  end
-end

--- a/mix.exs
+++ b/mix.exs
@@ -36,7 +36,7 @@ defmodule Memcachir.Mixfile do
     [{:benchfella, "~> 0.3.0", only: :dev},
      {:credo, "~> 0.7", only: [:dev, :test]},
      {:dialyxir, "~> 0.5", only: :dev, runtime: false},
-     {:elasticachex, "~> 1.0"},
+     {:elasticachex, "~> 1.1"},
      {:ex_doc, "~> 0.15", only: :dev},
      {:libring, "~> 1.1"},
      {:memcachex, "~> 0.4"},

--- a/mix.lock
+++ b/mix.lock
@@ -7,7 +7,7 @@
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "dynamic_compile": {:git, "https://github.com/JacobVorreuter/dynamic_compile.git", "d13d29c03d321e154adffb8eaa4b88b154a811fd", [tag: "d13d29c"]},
   "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
-  "elasticachex": {:hex, :elasticachex, "1.0.0", "a1b31d6fcab4894b7f1f9dfcd2c22cbbf6ed3f8b8146cb7f0ffe627722a679de", [:mix], [], "hexpm"},
+  "elasticachex": {:hex, :elasticachex, "1.1.1", "52d759f65122655218cac363ec06ea7b756fc23f2a65f68ad0f10b1dfea57193", [:mix], [{:socket, "~> 0.3", [hex: :socket, repo: "hexpm", optional: false]}], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "goldrush": {:git, "git://github.com/DeadZen/goldrush.git", "1d883423ac360b3536ca52dc733a0164bacf3109", [tag: "0.1.5"]},
   "lager": {:git, "git://github.com/basho/lager.git", "ad400896af5b1ad8b4f7a4d34e609b5a990640bb", [tag: "2.0.1"]},
@@ -16,4 +16,5 @@
   "memcachex": {:hex, :memcachex, "0.4.1", "12fe48370a5725fff790e1cdc0aa9ce2c28f685ad534bfbad5ef2302ee5003b6", [:mix], [{:connection, "~> 1.0.3", [hex: :connection, repo: "hexpm", optional: false]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, repo: "hexpm", optional: true]}], "hexpm"},
   "mero": {:git, "https://github.com/AdRoll/mero.git", "5c5eca1ba6f80838ec61e62c198282f1b0dc7d09", [tag: "v1.0.7"]},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], [], "hexpm"},
-  "proc": {:git, "https://github.com/miriampena/proc.git", "300c0d8a7dd4f23e42d33d11affdb26c3bcfbd67", [tag: "v1.0.0"]}}
+  "proc": {:git, "https://github.com/miriampena/proc.git", "300c0d8a7dd4f23e42d33d11affdb26c3bcfbd67", [tag: "v1.0.0"]},
+  "socket": {:hex, :socket, "0.3.13", "98a2ab20ce17f95fb512c5cadddba32b57273e0d2dba2d2e5f976c5969d0c632", [:mix], [], "hexpm"}}

--- a/test/failure_handling_test.exs
+++ b/test/failure_handling_test.exs
@@ -1,0 +1,51 @@
+defmodule FailureHandlingTest do
+  use ExUnit.Case, async: false
+
+  alias Memcachir.Cluster
+
+
+  @cluster ["localhost|localhost|11211", "localhost|127.0.0.1|11211"]
+
+
+  setup do
+    assert :ok == Application.stop(:memcachir)
+    Application.delete_env(:memcachir, :hosts)
+    Application.put_env(:memcachir, :elasticache, "localhost:11211")
+    assert :ok == Application.start(:memcachir)
+    :ok
+  end
+
+
+  test "survive ElastiCache failure" do
+    MockSocketModule.update([])
+
+    assert {:error, "unable to set: no_nodes"} == Memcachir.set("hello", "world")
+    assert {:error, "unable to delete: no_nodes"} == Memcachir.delete("hello")
+    assert {:error, "unable to get: no_nodes"} == Memcachir.get("hello")
+    assert {:error, "unable to flush: no_nodes"} == Memcachir.flush()
+
+    MockSocketModule.update(@cluster) # it's back up
+
+    assert {:ok} == Memcachir.set("hello", "world")
+  end
+
+  test "survive ElastiCache node replacement" do
+    MockSocketModule.update(@cluster)
+    Memcachir.set("hello", "world")
+
+    # one node is removed
+
+    [_ | other_servers] = @cluster
+    MockSocketModule.update(other_servers)
+
+    assert [{'127.0.0.1', 11211}] == Cluster.servers()
+    assert {:ok, "world"} == Memcachir.get("hello")
+
+    # one node is added
+
+    MockSocketModule.update(@cluster)
+
+    assert [{'localhost', 11211}, {'127.0.0.1', 11211}] == Cluster.servers()
+    assert {:ok, "world"} == Memcachir.get("hello")
+  end
+end

--- a/test/memcachir/util_test.exs
+++ b/test/memcachir/util_test.exs
@@ -12,4 +12,24 @@ defmodule Memcachir.UtilTest do
       [{'localhost', 1}, {'other', 2}]
   end
 
+  test "read elasticache configuration" do
+    defmodule MockElasticache do
+      def get_cluster_info("invalid", _port) do
+        {:error, "unable to connect"}
+      end
+
+      def get_cluster_info(host, port) do
+        {:ok, ["#{host}:#{port}"], "1.4.14"}
+      end
+    end
+
+    assert read_config_elasticache("localhost", MockElasticache) ==
+      [{'localhost', 11211}]
+    assert read_config_elasticache("localhost:11211", MockElasticache) ==
+      [{'localhost', 11211}]
+    assert read_config_elasticache("other:80", MockElasticache) ==
+      [{'other', 80}]
+    assert read_config_elasticache("invalid", MockElasticache) ==
+      []
+  end
 end

--- a/test/memcachir_test.exs
+++ b/test/memcachir_test.exs
@@ -1,16 +1,16 @@
 defmodule MemcachirTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: false
 
-  setup_all do
-    :timer.sleep(5000)
-  end
 
   setup do
+    assert :ok == Application.stop(:memcachir)
+    Application.delete_env(:memcachir, :elasticache)
+    Application.put_env(:memcachir, :hosts, "localhost:11211")
+    assert :ok == Application.start(:memcachir)
     assert {:ok} == Memcachir.flush()
-    Application.delete_env(:memcachir, :namespace)
-    Application.delete_env(:memcachir, :ttl)
     :ok
   end
+
 
   test "basic set get" do
     assert {:ok} == Memcachir.set("hello", "world")
@@ -18,9 +18,9 @@ defmodule MemcachirTest do
   end
 
   test "set with ttl" do
-    assert {:ok} == Memcachir.set("hello", "world", ttl: 2)
+    assert {:ok} == Memcachir.set("hello", "world", ttl: 1)
     assert {:ok, "world"} == Memcachir.get("hello")
-    :timer.sleep(2000)
+    :timer.sleep(1000)
     assert {:error, "Key not found"} == Memcachir.get("hello")
   end
 
@@ -35,5 +35,4 @@ defmodule MemcachirTest do
     assert {:ok} == Memcachir.flush()
     assert {:error, "Key not found"} == Memcachir.get("hello")
   end
-
 end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,38 @@
 ExUnit.start()
+
+
+defmodule MockSocketModule do
+
+  def start_link() do
+    Agent.start_link(fn -> [] end, name: __MODULE__)
+  end
+
+  def connect(_host, _port, _timeout) do
+    case get() do
+      [] -> {:error, :econnrefused}
+      _ -> {:ok, :socket}
+    end
+  end
+
+  def send_and_recv(_socket, command, _timeout) do
+    case command do
+      "version\n" -> {:ok, "VERSION 1.4.14\r\n"}
+      "config get cluster\n" ->
+        servers = get() |> Enum.join(" ")
+        {:ok, "CONFIG cluster 0 #{String.length(servers)}\r\n1\n#{servers}\n\r\nEND\r\n"}
+    end
+  end
+
+  def get() do
+    Agent.get(__MODULE__, fn servers -> servers end)
+  end
+
+  def update(servers) do
+    Agent.update(__MODULE__, fn (_) -> servers end)
+    send Memcachir.HealthCheck, :check
+    Process.sleep(200) # wait for it to be picked up
+  end
+end
+
+
+MockSocketModule.start_link()


### PR DESCRIPTION
Essentially, adds 2 things to the library:

(1) handle ElastiCache being down entirely (especially on application start)
(2) handle ElastiCache node removal/addition

Consists of:

 - **Supervisor**: root supervisor, **restarts all children if one fails**
 - **Cluster**: GenServer that manages mapping from hash key to server address
 - **HealthCheck**: GenServer that periodically compares in-memory server list with ElastiCache's and fails if they are out of sync (thereby triggering a restart)
 - **Pool**: supervisor for `:poolboy` children, one pool per server 